### PR TITLE
fix for @hapi/joi

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
-import Joi from 'joi';
-import moment from 'moment-timezone';
+const Joi = require('@hapi/joi');
+const moment = require('moment-timezone');
 
 module.exports = {
   base: Joi.string(),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "moment-timezone": "^0.5.13"
   },
   "peerDependencies": {
-    "joi": ">=9.0.0"
+    "@hapi/joi": ">=15.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
@@ -53,7 +53,7 @@
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.1.0",
     "istanbul": "^1.0.0-alpha.2",
-    "joi": "^9.0.0",
+    "@hapi/joi": "^15.0.3",
     "mocha": "^2.5.3"
   },
   "babel": {


### PR DESCRIPTION
use @hapi/joi

use of babel is questionable in my opinion. I've copied the index over and removed es6 import syntax for requires and updated requiring joi to @hapi/joi.
