### PR TITLE
[EN-68] Adding CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/articles/about-codeowners/
+
+* @SafetyCulture/localisation


### PR DESCRIPTION
We would like to add codeowners to all SafetyCulture repositories and have assigned to our localisation team based on the functionality of this repository.